### PR TITLE
Remove page title from System Info report

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -1228,8 +1228,8 @@ function edd_tools_sysinfo_get() {
 		$front_page_id = get_option( 'page_on_front' );
 		$blog_page_id = get_option( 'page_for_posts' );
 
-		$return .= 'Page On Front:            ' . ( $front_page_id != 0 ? get_the_title( $front_page_id ) . ' (#' . $front_page_id . ')' : 'Unset' ) . "\n";
-		$return .= 'Page For Posts:           ' . ( $blog_page_id != 0 ? get_the_title( $blog_page_id ) . ' (#' . $blog_page_id . ')' : 'Unset' ) . "\n";
+		$return .= 'Page On Front:            ' . ( $front_page_id != 0 ? '#' . $front_page_id : 'Unset' ) . "\n";
+		$return .= 'Page For Posts:           ' . ( $blog_page_id != 0 ? '#' . $blog_page_id : 'Unset' ) . "\n";
 	}
 
 	$return .= 'ABSPATH:                  ' . ABSPATH . "\n";


### PR DESCRIPTION
Fixes #8750

Proposed Changes:
1. Remove the title for Page on Front and Page for Posts from the System Info report. There is no need for it and it can prevent the EDD Support form from being submitted in some cases.